### PR TITLE
Changed the groupId to io.jenkins.plugins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <version>4.71</version>
     </parent>
 
-    <groupId>redhat.jenkins.plugins</groupId>
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>redhat-dependency-analytics</artifactId>
     <version>0.1.4-SNAPSHOT</version>
     <packaging>hpi</packaging>


### PR DESCRIPTION
Required: The <groupId> from the pom.xml should be io.jenkins.plugins instead of redhat.jenkins.plugins